### PR TITLE
Add internal bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags

--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# vim-lasttab
+
+A simple plugin for selecting the previous tab you were on. See the
+[vim documentation](help/lasttab.txt) for details, or just call `:help vim-lasttab` from within vim.
+
+## Installation
+
+Install via your favorite [plugin manager](https://www.google.com/search?q=vim+plugin+manager), as
+with any other repo-style plugin.
+
+## License
+
+Copyright (c) Vernon Jones 2015.  Distributed under the same terms as Vim itself.
+See `:help license`.

--- a/doc/lasttab.txt
+++ b/doc/lasttab.txt
@@ -1,0 +1,40 @@
+*lasttab.txt*  Plutin for asily switching to the previously-used tab
+
+Author:  Vernon Jones <vernonrjones@gmail.com>
+License: Same terms as Vim itself (see |license|)
+
+This plugin is only available if 'compatible' is not set.
+
+==============================================================================
+INTRODUCTION                                    *lasttab*
+
+This is a small plugin for selecting the previously-used tab. As a bonus, it
+also provides an overwritable mapping for easily selecting the previously-used
+buffer.
+
+Vim 7 is necessary for tab functionality.
+
+==============================================================================
+MAPPINGS                                        *lasttab-mappings*
+
+The mappings in this plugin are designed to avoid conflict by using |<Plug>|. To
+define your own keymappings for them, you can edit your |vimrc|.
+
+  Functionality           Mapping                        Default~
+  Previously-used tab     <Plug>LastTabLastUsedTab       <M-`>
+  Previously-used buffer  <Plug>LastTabLastUsedBuffer    <Leader>`
+
+Custtom mappings for these commands would usually look like: >
+
+  nmap <Leader>FOO <Plug>LastTabLastUsedTab
+  nmap <Leader>BAR <Plug>LastTabLastUsedBuffer
+<
+Where `FOO` and `BAR` are whatever you want.
+
+==============================================================================
+CONTRIBUTIONS                                   *lasttab-contributions*
+
+The main repo for the plugin is the `vernonrj/vim-lasttab` repo on GitHub:
+<https://github.com/vernonj/vim-lasttab>
+
+ vim:tw=78:ts=8:ft=help:norl:

--- a/plugin/lasttab.vim
+++ b/plugin/lasttab.vim
@@ -1,11 +1,38 @@
-" Switch to previous buffer
-nnoremap <Leader>` :b#<CR>
+" lasttab.vim - Easily switch to the previously-used tab
+"
+" File:    lasttab.vim
+" Author:  Vernon Jones <vernonrjones@gmail.com>
+" Version: 0.1.0
+" License: Vim License (see :help license)
 
-" switch to previous tab
-let g:lasttab = tabpagenr()
-nnoremap <M-`> :exe "tabn ".g:lasttab<CR>
+
+"" Switch to last-used tab
+
+" Hold last used-tab in global state
+let g:LastTab_lasttab = tabpagenr()
+
 augroup LastTabAutoGroup
-    autocmd!
-    autocmd TabLeave * let g:lasttab = tabpagenr()
+  autocmd!
+  " Update it every time you leave a tab
+  autocmd TabLeave * let g:LastTab_lasttab = tabpagenr()
 augroup END
 
+
+" Keymapping for the switch
+nnoremap <silent> <Plug>LastTabLastUsedTab :exe "tabn ".g:LastTab_lasttab<CR>
+
+if !hasmapto('<Plug>LastTabLastUsedTab') " Default
+  nmap <unique> <M-`> <Plug>LastTabLastUsedTab
+endif
+
+
+"" Switch to last-used buffer
+
+" Make a user-modifiable keymapping that can be used to pick the last buffer
+nnoremap <silent> <Plug>LastTabLastUsedBuffer :b#<CR>
+
+if !hasmapto('<Plug>LastTabLastUsedBuffer') " Default
+  nmap <unique> <Leader>` <Plug>LastTabLastUsedBuffer
+endif
+
+" vim: et ts=2 sts=2 sw=2


### PR DESCRIPTION
The existing bindings were hardcoded, so plugin users could not override them easily.

This PR adds the ability for users to define their own mappings to this functionality and also adds documentation to the plugin.